### PR TITLE
add `--bucket` argument to specify the release bucket

### DIFF
--- a/rootfs/usr/local/bin/bitnami-pkg
+++ b/rootfs/usr/local/bin/bitnami-pkg
@@ -11,7 +11,7 @@ print_usage() {
   echo "  unpack                     Download and unpack a package."
   echo ""
   echo "Options:"
-  echo "  -r, --repo                 Bitnami package repo (default: stacksmith)."
+  echo "  -b, --bucket               Package release bucket (default: stacksmith)."
   echo "  -c, --checksum             SHA256 verification checksum."
   echo "  -h, --help                 Show this help message and exit."
   echo ""
@@ -25,10 +25,13 @@ print_usage() {
   echo "  - Install package with arguments"
   echo "    \$ bitnami-pkg unpack mariadb-10.1.11-0 -- --password bitnami"
   echo ""
+  echo "  - Install package from testing"
+  echo "    \$ bitnami-pkg install mariadb-10.1.11-0 --bucket testing"
+  echo ""
 }
 
 # break up command line for easy parsing and check legal options
-ARGS=$(getopt -o r:c:h -l "repo:,checksum:,help" -n "bitnami-pkg" -- "$@")
+ARGS=$(getopt -o b:c:h -l "bucket:,checksum:,help" -n "bitnami-pkg" -- "$@")
 if [ $? -ne 0 ];
 then
   exit 1
@@ -37,10 +40,10 @@ fi
 eval set -- "$ARGS";
 while true; do
   case "$1" in
-    -r|--repo)
+    -b|--bucket)
       shift
       if [ -n "$1" ]; then
-        PACKAGE_REPO=$1
+        RELEASE_BUCKET=$1
         shift
       fi
       ;;
@@ -86,7 +89,7 @@ CACHE_ROOT=/tmp/bitnami/pkg/cache
 PACKAGE="$2-linux-x64"
 PACKAGE_ARGS=${@:3}
 PACKAGE_NAME=$(echo $PACKAGE | sed 's/-[0-9].*//')
-PACKAGE_REPO=${PACKAGE_REPO:-stacksmith}
+RELEASE_BUCKET=${RELEASE_BUCKET:-stacksmith}
 
 mkdir -p $INSTALL_ROOT
 cd $INSTALL_ROOT
@@ -96,7 +99,7 @@ if [ -f $CACHE_ROOT/$PACKAGE.tar.gz ]; then
   echo "===> $CACHE_ROOT/$PACKAGE_NAME.tar.gz already exists, skipping download."
   cp $CACHE_ROOT/$PACKAGE.tar.gz .
 else
-  curl -sSLO https://downloads.bitnami.com/files/$PACKAGE_REPO/$PACKAGE.tar.gz
+  curl -sSLO https://downloads.bitnami.com/files/$RELEASE_BUCKET/$PACKAGE.tar.gz
 fi
 
 if [ "$PACKAGE_SHA256" ]; then

--- a/rootfs/usr/local/bin/bitnami-pkg
+++ b/rootfs/usr/local/bin/bitnami-pkg
@@ -45,10 +45,10 @@ while true; do
       fi
       ;;
     -c|--checksum)
-      shift;
+      shift
       if [ -n "$1" ]; then
         PACKAGE_SHA256=$1
-        shift;
+        shift
       fi
       ;;
     -h|--help)
@@ -56,8 +56,8 @@ while true; do
       exit 0
       ;;
     --)
-      shift;
-      break;
+      shift
+      break
       ;;
   esac
 done

--- a/rootfs/usr/local/bin/bitnami-pkg
+++ b/rootfs/usr/local/bin/bitnami-pkg
@@ -11,6 +11,7 @@ print_usage() {
   echo "  unpack                     Download and unpack a package."
   echo ""
   echo "Options:"
+  echo "  -r, --repo                 Bitnami package repo (default: stacksmith)."
   echo "  -c, --checksum             SHA256 verification checksum."
   echo "  -h, --help                 Show this help message and exit."
   echo ""
@@ -27,7 +28,7 @@ print_usage() {
 }
 
 # break up command line for easy parsing and check legal options
-ARGS=$(getopt -o c:h -l "checksum:,help" -n "bitnami-pkg" -- "$@")
+ARGS=$(getopt -o r:c:h -l "repo:,checksum:,help" -n "bitnami-pkg" -- "$@")
 if [ $? -ne 0 ];
 then
   exit 1
@@ -36,6 +37,13 @@ fi
 eval set -- "$ARGS";
 while true; do
   case "$1" in
+    -r|--repo)
+      shift
+      if [ -n "$1" ]; then
+        PACKAGE_REPO=$1
+        shift
+      fi
+      ;;
     -c|--checksum)
       shift;
       if [ -n "$1" ]; then
@@ -78,6 +86,7 @@ CACHE_ROOT=/tmp/bitnami/pkg/cache
 PACKAGE="$2-linux-x64"
 PACKAGE_ARGS=${@:3}
 PACKAGE_NAME=$(echo $PACKAGE | sed 's/-[0-9].*//')
+PACKAGE_REPO=${PACKAGE_REPO:-stacksmith}
 
 mkdir -p $INSTALL_ROOT
 cd $INSTALL_ROOT
@@ -87,7 +96,7 @@ if [ -f $CACHE_ROOT/$PACKAGE.tar.gz ]; then
   echo "===> $CACHE_ROOT/$PACKAGE_NAME.tar.gz already exists, skipping download."
   cp $CACHE_ROOT/$PACKAGE.tar.gz .
 else
-  curl -sSLO https://downloads.bitnami.com/files/stacksmith/$PACKAGE.tar.gz
+  curl -sSLO https://downloads.bitnami.com/files/$PACKAGE_REPO/$PACKAGE.tar.gz
 fi
 
 if [ "$PACKAGE_SHA256" ]; then

--- a/rootfs/usr/local/bin/bitnami-pkg
+++ b/rootfs/usr/local/bin/bitnami-pkg
@@ -23,7 +23,7 @@ print_usage() {
   echo "    \$ bitnami-pkg install nginx-1.9.10-0 --checksum 15565d06b18c2e3710fc08e579ddb3d0e39aa663264a0f7404f0743cb4cdb58d"
   echo ""
   echo "  - Install package with arguments"
-  echo "    \$ bitnami-pkg unpack mariadb-10.1.11-0 -- --password bitnami"
+  echo "    \$ bitnami-pkg install mariadb-10.1.11-0 -- --password bitnami"
   echo ""
   echo "  - Install package from testing"
   echo "    \$ bitnami-pkg install mariadb-10.1.11-0 --bucket testing"


### PR DESCRIPTION
defaults to the `stacksmith` bucket

example usage:

```bash
bitnami-pkg unpack redis-3.0.6-2 --bucket testing
```