### PR TITLE
Switch to library/debian for Debian base

### DIFF
--- a/debian/jessie/Dockerfile
+++ b/debian/jessie/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/debian:jessie
+FROM debian:8.5
 MAINTAINER Bitnami <containers@bitnami.com>
 
 RUN apt-get update && \

--- a/debian/jessie/Dockerfile
+++ b/debian/jessie/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:8.5
+FROM debian@sha256:ffb60fdbc401b2a692eef8d04616fca15905dce259d1499d96521970ed0bec36
 MAINTAINER Bitnami <containers@bitnami.com>
 
 RUN apt-get update && \

--- a/debian/jessie/Dockerfile
+++ b/debian/jessie/Dockerfile
@@ -3,7 +3,6 @@ MAINTAINER Bitnami <containers@bitnami.com>
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl ca-certificates sudo procps libaio1 && \
-  apt-get upgrade -y && \
   useradd -ms /bin/bash bitnami && \
   mkdir -p /opt/bitnami && chown bitnami:bitnami /opt/bitnami && \
   sed -i -e 's/\s*Defaults\s*secure_path\s*=/# Defaults secure_path=/' /etc/sudoers && \

--- a/debian/wheezy/Dockerfile
+++ b/debian/wheezy/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:7.11
+FROM debian@sha256:1e21d6ccae906c032fb20c9d5a8d834d6673b6f760aefcf41315a253f87d9c2b
 MAINTAINER Bitnami <containers@bitnami.com>
 
 RUN apt-get update && \

--- a/debian/wheezy/Dockerfile
+++ b/debian/wheezy/Dockerfile
@@ -3,7 +3,6 @@ MAINTAINER Bitnami <containers@bitnami.com>
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl ca-certificates sudo procps libaio1 && \
-  apt-get upgrade -y && \
   useradd -ms /bin/bash bitnami && \
   mkdir -p /opt/bitnami && chown bitnami:bitnami /opt/bitnami && \
   sed -i -e 's/\s*Defaults\s*secure_path\s*=/# Defaults secure_path=/' /etc/sudoers && \

--- a/debian/wheezy/Dockerfile
+++ b/debian/wheezy/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/debian:wheezy
+FROM debian:7.11
 MAINTAINER Bitnami <containers@bitnami.com>
 
 RUN apt-get update && \


### PR DESCRIPTION
@sameersbn wanted to check with you on this, it seems the library/debian maintainer re-push tags on updates (unlike Ubuntu). If we want to ensure reproducibility, we could use the content hash (https://github.com/docker-library/repo-info/blob/master/repos/debian/tag-details.md#debian85) instead. Thoughts?